### PR TITLE
fix: eslint config in pack n play

### DIFF
--- a/dev-packages/pack-n-play/.eslintrc.js
+++ b/dev-packages/pack-n-play/.eslintrc.js
@@ -1,0 +1,15 @@
+// Config file for esilnt used by gts.
+
+const path = require('path');
+
+// 1. Find the absolute path to the 'gts' package's directory
+//    This forces Node.js to look up in the directory tree (hoisted root)
+const GTS_CONFIG_PATH = path.dirname(
+  require.resolve('gts/package.json', {paths: [__dirname]}),
+);
+
+module.exports = {
+  // Use the absolute path provided by Node's resolution
+  // This bypasses the relative path failure completely.
+  extends: [GTS_CONFIG_PATH],
+};

--- a/dev-packages/pack-n-play/.eslintrc.js
+++ b/dev-packages/pack-n-play/.eslintrc.js
@@ -1,4 +1,4 @@
-// Config file for esilnt used by gts.
+// Config file for eslint used by gts.
 
 const path = require('path');
 

--- a/dev-packages/pack-n-play/.eslintrc.json
+++ b/dev-packages/pack-n-play/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "./node_modules/gts"
-}

--- a/dev-packages/pack-n-play/package.json
+++ b/dev-packages/pack-n-play/package.json
@@ -23,7 +23,7 @@
     "compile": "tsc -p tsconfig.json",
     "docs": "node -e 'fs.mkdirSync(`docs`)'",
     "fix": "gts fix",
-    "lint": "if [ -d node_modules/gts ]; then GTS_PATH='./node_modules/gts'; else GTS_PATH='./../../node_modules/gts'; fi && echo \"{\\\"extends\\\": \\\"${GTS_PATH}\\\"}\" > .eslintrc.json && gts check && git checkout .eslintrc.json",
+    "lint": "gts check",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "samples-test": "",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "samples-test": "npm run samples-test --ws",
     "system-test": "npm run system-test --ws",
     "prelint": "npm run prelint --ws",
-    "lint": "npm run lint --ws"
+    "lint": "npm run lint --ws",
+    "fix": "npm run fix --ws"
   },
   "workspaces": [
     "dev-packages/pack-n-play"


### PR DESCRIPTION
One of the features of workspaces is that hoist all the dependencies, for doing this the dependencies are installed in the root of the workspace. This introduce an issue with current eslint config file, for example

Working locally on pack-n-play after setting up the environment the files look this:

./node_modules/*
./dev-packages/pack-n-play/.eslintrc.json

And when running gts check or gts fix, the command fails because eslintrc is extending from ./node_modules/gts and can't find it in ./dev-packages/pack-n-play/node_modules/gts, changed this to js file so we can find the absolute path to gts.