### PR TITLE
fix: package.json links in gax, tools and logging utils

### DIFF
--- a/dev-packages/logging-utils/package.json
+++ b/dev-packages/logging-utils/package.json
@@ -22,8 +22,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/googleapis/gax-nodejs.git",
-    "directory": "logging-utils"
+    "directory": "dev-packages/logging-utils",
+    "url": "https://github.com/googleapis/google-cloud-node-core.git"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
@@ -35,6 +35,10 @@
     "sinon": "^21.0.0",
     "typescript": "^5.1.6"
   },
+  "bugs": {
+    "url": "https://github.com/googleapis/google-cloud-node-core/issues"
+  },
+  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/dev-packages/logging-utils",
   "engines": {
     "node": ">=14"
   }

--- a/packages/gax/package.json
+++ b/packages/gax/package.json
@@ -99,15 +99,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/googleapis/gax-nodejs.git",
-    "directory": "gax"
+    "directory": "packages/gax",
+    "url": "https://github.com/googleapis/google-cloud-node-core.git"
   },
   "author": "Google API Authors",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/googleapis/gax-nodejs/issues"
+    "url": "https://github.com/googleapis/google-cloud-node-core/issues"
   },
-  "homepage": "https://github.com/googleapis/gax-nodejs#readme",
+  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gax",
   "engines": {
     "node": ">=18"
   },

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -40,8 +40,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/googleapis/gax-nodejs.git",
-    "directory": "gapic-tools"
+    "directory": "packages/tools",
+    "url": "https://github.com/googleapis/google-cloud-node-core.git"
   },
   "devDependencies": {
     "@babel/cli": "^7.26.4",
@@ -58,6 +58,10 @@
     "protobufjs": "^7.5.0",
     "typescript": "^5.7.3"
   },
+  "bugs": {
+    "url": "https://github.com/googleapis/google-cloud-node-core/issues"
+  },
+  "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/tools",
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
build: package.json links in gax, tools and logging utils
END_COMMIT_OVERRIDE