### PR TITLE
fix: set rimraf as dev dependency

### DIFF
--- a/packages/gaxios/package.json
+++ b/packages/gaxios/package.json
@@ -97,7 +97,7 @@
     "typescript": "^5.8.3",
     "webpack": "^5.35.0",
     "webpack-cli": "^6.0.1",
-    "rimraf": "^6.1.0"
+    "rimraf": "^5.0.1"
   },
   "dependencies": {
     "extend": "^3.0.2",

--- a/packages/gaxios/package.json
+++ b/packages/gaxios/package.json
@@ -96,13 +96,13 @@
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
     "webpack": "^5.35.0",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "rimraf": "^6.1.0"
   },
   "dependencies": {
     "extend": "^3.0.2",
     "https-proxy-agent": "^7.0.1",
-    "node-fetch": "^3.3.2",
-    "rimraf": "^5.0.1"
+    "node-fetch": "^3.3.2"
   },
   "homepage": "https://github.com/googleapis/google-cloud-node-core/tree/main/packages/gaxios"
 }


### PR DESCRIPTION
Setting rimraf as dev dependency since it is only used for testing.
Will fix https://github.com/googleapis/google-cloud-node-core/issues/825

Note: we can't upgrade to latest version because node 18 is not supported.

