### PR TITLE
build: add missing docs and docs-test scripts

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -7,7 +7,9 @@
         "prelint": "echo 'No prelint needed for script tests'",
         "lint": "echo 'No linting needed for script tests'",
         "samples-test": "echo 'no samples test!'",
-        "system-test": "echo 'no system test!'"
+        "system-test": "echo 'no system test!'",
+        "docs-test": "echo no docs tests",
+        "docs": "echo no docs needed"
     },
     "author": "Google Inc.",
     "license": "Apache-2.0",

--- a/dev-packages/pack-n-play/package.json
+++ b/dev-packages/pack-n-play/package.json
@@ -22,6 +22,7 @@
     "clean": "gts clean",
     "compile": "tsc -p tsconfig.json",
     "docs": "echo no docs needed",
+    "docs-test": "echo no docs tests",
     "fix": "gts fix",
     "lint": "gts check",
     "prepare": "npm run compile",

--- a/generator/gapic-generator-typescript/package.json
+++ b/generator/gapic-generator-typescript/package.json
@@ -46,7 +46,9 @@
     "test": "bazelisk test --test_output=errors //:unit_tests",
     "ts-test-application": "mocha bazel-bin/typescript/test/test-application/test-ts --timeout 600000",
     "system-test": "echo 'no system test'",
-    "samples-test": "echo 'no samples test'"
+    "samples-test": "echo 'no samples test'",
+    "docs": "echo no docs needed",
+    "docs-test": "echo no docs tests"
   },
   "dependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/logging-utils/package.json
+++ b/packages/logging-utils/package.json
@@ -17,7 +17,9 @@
     "prepare": "npm run compile",
     "precompile": "gts clean",
     "samples-test": "cd samples/ && npm link ../ && npm install && npm test && cd ../",
-    "system-test": "echo no system tests 🙀"
+    "system-test": "echo no system tests 🙀",
+    "docs": "echo no docs needed",
+    "docs-test": "echo no docs tests"
   },
   "author": "Google API Authors",
   "license": "Apache-2.0",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -17,7 +17,9 @@
     "prepare": "npm run compile",
     "precompile": "gts clean",
     "system-test": "echo 'no system-test'",
-    "samples-test": "echo 'no samples'"
+    "samples-test": "echo 'no samples'",
+    "docs": "echo no docs needed",
+    "docs-test": "echo no docs tests"
   },
   "bin": {
     "compileProtos": "./build/src/compileProtos.js",


### PR DESCRIPTION
Add docs and docs-test in all the packages.

We are going to setup the docs script in the repo, adding the script in all the packages.