### PR TITLE
fix(deps): Remove last rimraf mention

### DIFF
--- a/dev-packages/pack-n-play/package.json
+++ b/dev-packages/pack-n-play/package.json
@@ -36,7 +36,6 @@
     "@types/node": "^22.13.10",
     "@types/npm-packlist": "^7.0.3",
     "@types/once": "^1.4.5",
-    "@types/rimraf": "^4.0.5",
     "@types/tar": "^6.1.13",
     "@types/tmp": "^0.2.6",
     "c8": "^10.1.3",

--- a/packages/gax/package.json
+++ b/packages/gax/package.json
@@ -19,8 +19,7 @@
     "object-hash": "^3.0.0",
     "proto3-json-serializer": "3.0.4",
     "protobufjs": "^7.5.4",
-    "retry-request": "8.0.2",
-    "rimraf": "^5.0.1"
+    "retry-request": "8.0.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-methods": "^7.18.6",


### PR DESCRIPTION
Hey :wave:

I was also a little bit confused to see rimraf sneak up in my dependency tree.

Here's a MR to remove the unused rimraf dependency for gax, and unused @types/rimraf for pack-n-play.

Similar to #852, additional fix for #851

Cheers!