### PR TITLE
docs: regenerate baseline docs with 2026 copyright

### DIFF
--- a/generator/gapic-generator-typescript/baselines/asset-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/asset',

--- a/generator/gapic-generator-typescript/baselines/asset-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/esm/src/v1/asset_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/esm/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/esm/test/gapic_asset_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.batch_get_assets_history.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.batch_get_assets_history.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.create_feed.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.create_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.delete_feed.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.delete_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.export_assets.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.export_assets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.get_feed.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.get_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.list_feeds.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.list_feeds.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.update_feed.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset-esm/samples/generated/v1/asset_service.update_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/asset',

--- a/generator/gapic-generator-typescript/baselines/asset/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.batch_get_assets_history.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.batch_get_assets_history.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.create_feed.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.create_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.delete_feed.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.delete_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.export_assets.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.export_assets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.get_feed.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.get_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.list_feeds.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.list_feeds.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.update_feed.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/samples/generated/v1/asset_service.update_feed.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/src/v1/asset_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/src/v1/asset_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/asset/test/gapic_asset_service_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/asset/test/gapic_asset_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'storage',

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/src/v1beta1/big_query_storage_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/esm/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.create_read_session.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.create_read_session.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.finalize_stream.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.finalize_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.read_rows.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.read_rows.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.split_read_stream.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage-esm/samples/generated/v1beta1/big_query_storage.split_read_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'storage',

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.batch_create_read_session_streams.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.create_read_session.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.create_read_session.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.finalize_stream.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.finalize_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.read_rows.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.read_rows.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.split_read_stream.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/samples/generated/v1beta1/big_query_storage.split_read_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/src/v1beta1/big_query_storage_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-storage/test/gapic_big_query_storage_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'bigquery',

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/dataset_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/dataset_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/job_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/job_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/model_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/model_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/project_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/project_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/routine_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/routine_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/row_access_policy_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/row_access_policy_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/table_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/src/v2/table_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_dataset_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_dataset_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_job_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_job_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_model_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_model_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_project_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_project_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_routine_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_routine_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_row_access_policy_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_row_access_policy_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_table_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/esm/test/gapic_table_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.delete_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.delete_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.get_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.get_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.insert_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.insert_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.list_datasets.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.list_datasets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.patch_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.patch_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.undelete_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.undelete_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.update_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/dataset_service.update_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.cancel_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.cancel_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.delete_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.delete_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.get_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.get_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.get_query_results.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.get_query_results.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.insert_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.insert_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.list_jobs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.list_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.query.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/job_service.query.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/model_service.delete_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/model_service.delete_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/model_service.get_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/model_service.get_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/model_service.list_models.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/model_service.list_models.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/model_service.patch_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/model_service.patch_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/project_service.get_service_account.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/project_service.get_service_account.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.delete_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.delete_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.get_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.get_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.insert_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.insert_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.list_routines.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.list_routines.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.patch_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.patch_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.update_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/routine_service.update_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/row_access_policy_service.list_row_access_policies.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/row_access_policy_service.list_row_access_policies.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.delete_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.delete_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.get_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.get_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.insert_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.insert_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.list_tables.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.list_tables.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.patch_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.patch_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.update_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2-esm/samples/generated/v2/table_service.update_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'bigquery',

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.delete_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.delete_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.get_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.get_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.insert_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.insert_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.list_datasets.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.list_datasets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.patch_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.patch_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.undelete_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.undelete_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.update_dataset.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/dataset_service.update_dataset.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.cancel_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.cancel_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.delete_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.delete_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.get_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.get_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.get_query_results.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.get_query_results.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.insert_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.insert_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.list_jobs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.list_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.query.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/job_service.query.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/model_service.delete_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/model_service.delete_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/model_service.get_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/model_service.get_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/model_service.list_models.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/model_service.list_models.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/model_service.patch_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/model_service.patch_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/project_service.get_service_account.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/project_service.get_service_account.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.delete_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.delete_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.get_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.get_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.insert_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.insert_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.list_routines.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.list_routines.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.patch_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.patch_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.update_routine.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/routine_service.update_routine.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/row_access_policy_service.list_row_access_policies.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/row_access_policy_service.list_row_access_policies.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.delete_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.delete_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.get_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.get_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.insert_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.insert_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.list_tables.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.list_tables.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.patch_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.patch_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.update_table.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/samples/generated/v2/table_service.update_table.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/dataset_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/dataset_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/job_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/job_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/model_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/model_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/project_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/project_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/routine_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/routine_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/row_access_policy_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/row_access_policy_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/table_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/src/v2/table_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_dataset_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_dataset_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_job_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_job_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_model_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_model_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_project_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_project_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_routine_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_routine_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_row_access_policy_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_row_access_policy_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_table_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/bigquery-v2/test/gapic_table_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/compute',

--- a/generator/gapic-generator-typescript/baselines/compute-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/src/v1/addresses_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/src/v1/region_operations_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/test/gapic_addresses_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/esm/test/gapic_region_operations_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/addresses.aggregated_list.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/addresses.aggregated_list.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/addresses.delete.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/addresses.delete.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/addresses.insert.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/addresses.insert.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/addresses.list.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/addresses.list.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/region_operations.get.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/region_operations.get.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/region_operations.wait.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute-esm/samples/generated/v1/region_operations.wait.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/compute',

--- a/generator/gapic-generator-typescript/baselines/compute/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/addresses.aggregated_list.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/addresses.aggregated_list.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/addresses.delete.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/addresses.delete.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/addresses.insert.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/addresses.insert.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/addresses.list.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/addresses.list.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/region_operations.get.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/region_operations.get.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/region_operations.wait.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/samples/generated/v1/region_operations.wait.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/src/v1/addresses_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/src/v1/addresses_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/src/v1/region_operations_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/src/v1/region_operations_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/test/gapic_addresses_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/test/gapic_addresses_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/compute/test/gapic_region_operations_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/compute/test/gapic_region_operations_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'deprecatedtest',

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/src/v1/deprecated_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/samples/generated/v1/deprecated_service.fast_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/samples/generated/v1/deprecated_service.fast_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/samples/generated/v1/deprecated_service.slow_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest-esm/samples/generated/v1/deprecated_service.slow_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'deprecatedtest',

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/samples/generated/v1/deprecated_service.fast_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/samples/generated/v1/deprecated_service.fast_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/samples/generated/v1/deprecated_service.slow_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/samples/generated/v1/deprecated_service.slow_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/src/v1/deprecated_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/deprecatedtest/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/deprecatedtest/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/compliance_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/identity_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/messaging_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/sequence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/src/v1beta1/testing_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_compliance_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_identity_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_messaging_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/disable-packing-test/test/gapic_testing_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'dlp',

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/esm/src/v2/dlp_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/esm/src/v2/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/esm/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/esm/test/gapic_dlp_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.activate_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.activate_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.cancel_dlp_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.cancel_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_deidentify_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_dlp_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_inspect_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_stored_info_type.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.create_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.deidentify_content.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.deidentify_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_deidentify_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_dlp_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_inspect_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_stored_info_type.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.delete_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_deidentify_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_dlp_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_inspect_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_stored_info_type.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.get_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.inspect_content.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.inspect_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_deidentify_templates.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_deidentify_templates.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_dlp_jobs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_dlp_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_info_types.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_info_types.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_inspect_templates.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_inspect_templates.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_job_triggers.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_job_triggers.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_stored_info_types.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.list_stored_info_types.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.redact_image.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.redact_image.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.reidentify_content.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.reidentify_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.update_deidentify_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.update_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.update_inspect_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.update_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.update_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.update_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.update_stored_info_type.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp-esm/samples/generated/v2/dlp_service.update_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'dlp',

--- a/generator/gapic-generator-typescript/baselines/dlp/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.activate_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.activate_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.cancel_dlp_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.cancel_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_deidentify_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_dlp_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_inspect_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_stored_info_type.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.create_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.deidentify_content.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.deidentify_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_deidentify_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_dlp_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_inspect_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_stored_info_type.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.delete_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_deidentify_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_dlp_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_dlp_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_inspect_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_stored_info_type.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.get_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.inspect_content.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.inspect_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_deidentify_templates.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_deidentify_templates.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_dlp_jobs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_dlp_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_info_types.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_info_types.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_inspect_templates.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_inspect_templates.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_job_triggers.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_job_triggers.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_stored_info_types.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.list_stored_info_types.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.redact_image.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.redact_image.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.reidentify_content.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.reidentify_content.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.update_deidentify_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.update_deidentify_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.update_inspect_template.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.update_inspect_template.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.update_job_trigger.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.update_job_trigger.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.update_stored_info_type.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/samples/generated/v2/dlp_service.update_stored_info_type.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/src/v2/dlp_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/src/v2/dlp_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/src/v2/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/dlp/test/gapic_dlp_service_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'kms',

--- a/generator/gapic-generator-typescript/baselines/kms-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/esm/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/esm/src/v1/key_management_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/esm/test/gapic_key_management_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.asymmetric_decrypt.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.asymmetric_decrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.asymmetric_sign.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.asymmetric_sign.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.create_crypto_key.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.create_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.create_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.create_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.create_import_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.create_import_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.create_key_ring.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.create_key_ring.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.decrypt.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.decrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.destroy_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.destroy_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.encrypt.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.encrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_crypto_key.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_import_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_import_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_key_ring.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_key_ring.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_public_key.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.get_public_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.import_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.import_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.list_crypto_key_versions.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.list_crypto_key_versions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.list_crypto_keys.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.list_crypto_keys.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.list_import_jobs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.list_import_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.list_key_rings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.list_key_rings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.restore_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.restore_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key_primary_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key_primary_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms-esm/samples/generated/v1/key_management_service.update_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'kms',

--- a/generator/gapic-generator-typescript/baselines/kms/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.asymmetric_decrypt.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.asymmetric_decrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.asymmetric_sign.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.asymmetric_sign.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.create_crypto_key.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.create_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.create_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.create_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.create_import_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.create_import_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.create_key_ring.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.create_key_ring.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.decrypt.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.decrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.destroy_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.destroy_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.encrypt.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.encrypt.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_crypto_key.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_import_job.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_import_job.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_key_ring.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_key_ring.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_public_key.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.get_public_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.import_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.import_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.list_crypto_key_versions.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.list_crypto_key_versions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.list_crypto_keys.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.list_crypto_keys.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.list_import_jobs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.list_import_jobs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.list_key_rings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.list_key_rings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.restore_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.restore_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key_primary_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key_primary_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key_version.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/samples/generated/v1/key_management_service.update_crypto_key_version.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/src/v1/key_management_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/src/v1/key_management_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/kms/test/gapic_key_management_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'logging',

--- a/generator/gapic-generator-typescript/baselines/logging-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/v2/config_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/v2/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/v2/logging_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/src/v2/metrics_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/test/gapic_config_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/test/gapic_logging_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/esm/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.create_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.create_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.create_sink.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.create_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.create_view.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.create_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_sink.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_view.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.delete_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_settings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_sink.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_view.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.get_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.list_buckets.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.list_buckets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.list_exclusions.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.list_exclusions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.list_sinks.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.list_sinks.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.list_views.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.list_views.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_settings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_sink.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_view.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/config_service_v2.update_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.delete_log.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.delete_log.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_logs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_logs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.create_log_metric.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.create_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.delete_log_metric.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.delete_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.get_log_metric.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.get_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.list_log_metrics.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.list_log_metrics.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.update_log_metric.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging-esm/samples/generated/v2/metrics_service_v2.update_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'logging',

--- a/generator/gapic-generator-typescript/baselines/logging/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.copy_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.create_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.create_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.create_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.create_sink.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.create_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.create_view.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.create_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.delete_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.delete_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.delete_sink.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.delete_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.delete_view.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.delete_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_cmek_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_settings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_sink.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_view.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.get_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.list_buckets.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.list_buckets.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.list_exclusions.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.list_exclusions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.list_sinks.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.list_sinks.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.list_views.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.list_views.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.undelete_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_bucket.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_bucket.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_cmek_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_exclusion.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_settings.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_settings.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_sink.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_sink.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_view.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/config_service_v2.update_view.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.delete_log.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.delete_log.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.list_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.list_logs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.list_logs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.list_monitored_resource_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.tail_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/logging_service_v2.write_log_entries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.create_log_metric.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.create_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.delete_log_metric.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.delete_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.get_log_metric.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.get_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.list_log_metrics.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.list_log_metrics.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.update_log_metric.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/samples/generated/v2/metrics_service_v2.update_log_metric.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/src/v2/config_service_v2_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/src/v2/config_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/src/v2/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/src/v2/logging_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/src/v2/metrics_service_v2_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/test/gapic_config_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/test/gapic_logging_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/logging/test/gapic_metrics_service_v2_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'monitoring',

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/alert_policy_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/group_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/metric_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/notification_channel_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/service_monitoring_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/src/v3/uptime_check_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_alert_policy_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_group_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_metric_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_notification_channel_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/esm/test/gapic_uptime_check_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.create_alert_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.create_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.delete_alert_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.delete_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.get_alert_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.get_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.list_alert_policies.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.list_alert_policies.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.update_alert_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/alert_policy_service.update_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.create_group.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.create_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.delete_group.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.delete_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.get_group.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.get_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.list_group_members.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.list_group_members.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.list_groups.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.list_groups.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.update_group.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/group_service.update_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.create_metric_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.create_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.create_time_series.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.create_time_series.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.delete_metric_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.delete_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.get_metric_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.get_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.get_monitored_resource_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.get_monitored_resource_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.list_metric_descriptors.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.list_metric_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.list_monitored_resource_descriptors.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.list_monitored_resource_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.list_time_series.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/metric_service.list_time_series.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.create_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.create_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.delete_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.delete_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.list_notification_channels.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.list_notification_channels.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.update_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.update_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.verify_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/notification_channel_service.verify_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.create_service.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.create_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.create_service_level_objective.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.create_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.delete_service.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.delete_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.delete_service_level_objective.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.delete_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.get_service.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.get_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.get_service_level_objective.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.get_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.list_service_level_objectives.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.list_service_level_objectives.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.list_services.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.list_services.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.update_service.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.update_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.update_service_level_objective.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/service_monitoring_service.update_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.create_uptime_check_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.create_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.delete_uptime_check_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.delete_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.get_uptime_check_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.get_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.list_uptime_check_configs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.list_uptime_check_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.list_uptime_check_ips.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.list_uptime_check_ips.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.update_uptime_check_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring-esm/samples/generated/v3/uptime_check_service.update_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'monitoring',

--- a/generator/gapic-generator-typescript/baselines/monitoring/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.create_alert_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.create_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.delete_alert_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.delete_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.get_alert_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.get_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.list_alert_policies.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.list_alert_policies.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.update_alert_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/alert_policy_service.update_alert_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.create_group.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.create_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.delete_group.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.delete_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.get_group.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.get_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.list_group_members.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.list_group_members.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.list_groups.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.list_groups.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.update_group.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/group_service.update_group.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.create_metric_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.create_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.create_time_series.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.create_time_series.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.delete_metric_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.delete_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.get_metric_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.get_metric_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.get_monitored_resource_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.get_monitored_resource_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.list_metric_descriptors.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.list_metric_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.list_monitored_resource_descriptors.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.list_monitored_resource_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.list_time_series.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/metric_service.list_time_series.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.create_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.create_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.delete_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.delete_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel_descriptor.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.get_notification_channel_verification_code.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.list_notification_channel_descriptors.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.list_notification_channels.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.list_notification_channels.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.send_notification_channel_verification_code.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.update_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.update_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.verify_notification_channel.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/notification_channel_service.verify_notification_channel.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.create_service.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.create_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.create_service_level_objective.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.create_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.delete_service.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.delete_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.delete_service_level_objective.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.delete_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.get_service.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.get_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.get_service_level_objective.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.get_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.list_service_level_objectives.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.list_service_level_objectives.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.list_services.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.list_services.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.update_service.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.update_service.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.update_service_level_objective.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/service_monitoring_service.update_service_level_objective.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.create_uptime_check_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.create_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.delete_uptime_check_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.delete_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.get_uptime_check_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.get_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.list_uptime_check_configs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.list_uptime_check_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.list_uptime_check_ips.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.list_uptime_check_ips.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.update_uptime_check_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/samples/generated/v3/uptime_check_service.update_uptime_check_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/src/v3/alert_policy_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/src/v3/group_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/src/v3/group_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/src/v3/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/src/v3/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/src/v3/metric_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/src/v3/metric_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/src/v3/notification_channel_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/src/v3/service_monitoring_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/src/v3/uptime_check_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_alert_policy_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_group_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_metric_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_notification_channel_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_service_monitoring_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/monitoring/test/gapic_uptime_check_service_v3.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'naming',

--- a/generator/gapic-generator-typescript/baselines/naming-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/esm/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/esm/src/v1beta1/naming_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/esm/test/gapic_naming_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.api_endpoint.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.api_endpoint.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.check_long_running_progress.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.check_long_running_progress.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.get_project_id.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.get_project_id.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.get_reserved_word.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.get_reserved_word.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.initialize.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.initialize.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.long_running.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.long_running.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method_async.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method_async.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method_stream.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.paginated_method_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.port.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.port.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.scopes.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.scopes.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.service_path.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming-esm/samples/generated/v1beta1/naming.service_path.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'naming',

--- a/generator/gapic-generator-typescript/baselines/naming/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.api_endpoint.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.api_endpoint.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.check_long_running_progress.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.check_long_running_progress.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.create_a_b_c_d_e_something.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.get_project_id.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.get_project_id.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.get_reserved_word.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.get_reserved_word.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.initialize.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.initialize.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.long_running.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.long_running.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.paginated_method.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.paginated_method.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.paginated_method_async.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.paginated_method_async.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.paginated_method_stream.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.paginated_method_stream.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.port.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.port.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.scopes.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.scopes.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.service_path.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/samples/generated/v1beta1/naming.service_path.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/src/v1beta1/naming_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/src/v1beta1/naming_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/naming/test/gapic_naming_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'redis',

--- a/generator/gapic-generator-typescript/baselines/redis-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/esm/src/v1beta1/cloud_redis_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/esm/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/esm/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.create_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.create_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.delete_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.delete_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.export_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.export_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.failover_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.failover_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.get_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.get_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.import_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.import_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.list_instances.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.list_instances.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.update_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis-esm/samples/generated/v1beta1/cloud_redis.update_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'redis',

--- a/generator/gapic-generator-typescript/baselines/redis/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.create_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.create_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.delete_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.delete_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.export_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.export_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.failover_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.failover_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.get_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.get_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.import_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.import_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.list_instances.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.list_instances.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.update_instance.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/samples/generated/v1beta1/cloud_redis.update_instance.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/src/v1beta1/cloud_redis_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/redis/test/gapic_cloud_redis_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'retail',

--- a/generator/gapic-generator-typescript/baselines/retail-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/analytics_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/analytics_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/branch_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/branch_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/catalog_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/catalog_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/completion_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/completion_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/control_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/control_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/conversational_search_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/conversational_search_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/generative_question_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/generative_question_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/merchant_center_account_link_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/merchant_center_account_link_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/model_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/model_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/prediction_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/prediction_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/product_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/product_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/project_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/project_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/search_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/search_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/serving_config_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/serving_config_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/user_event_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/src/v2alpha/user_event_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_analytics_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_analytics_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_branch_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_branch_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_catalog_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_catalog_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_completion_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_completion_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_control_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_control_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_conversational_search_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_conversational_search_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_generative_question_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_generative_question_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_merchant_center_account_link_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_merchant_center_account_link_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_model_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_model_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_prediction_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_prediction_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_product_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_product_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_project_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_project_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_search_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_search_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_serving_config_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_serving_config_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_user_event_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/esm/test/gapic_user_event_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/analytics_service.export_analytics_metrics.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/analytics_service.export_analytics_metrics.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/branch_service.get_branch.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/branch_service.get_branch.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/branch_service.list_branches.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/branch_service.list_branches.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.add_catalog_attribute.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.add_catalog_attribute.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.batch_remove_catalog_attributes.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.batch_remove_catalog_attributes.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.get_attributes_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.get_attributes_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.get_completion_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.get_completion_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.get_default_branch.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.get_default_branch.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.list_catalogs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.list_catalogs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.remove_catalog_attribute.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.remove_catalog_attribute.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.replace_catalog_attribute.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.replace_catalog_attribute.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.set_default_branch.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.set_default_branch.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.update_attributes_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.update_attributes_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.update_catalog.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.update_catalog.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.update_completion_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/catalog_service.update_completion_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/completion_service.complete_query.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/completion_service.complete_query.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/completion_service.import_completion_data.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/completion_service.import_completion_data.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.create_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.create_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.delete_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.delete_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.get_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.get_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.list_controls.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.list_controls.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.update_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/control_service.update_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/conversational_search_service.conversational_search.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/conversational_search_service.conversational_search.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.batch_update_generative_question_configs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.batch_update_generative_question_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.get_generative_questions_feature_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.get_generative_questions_feature_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.list_generative_question_configs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.list_generative_question_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.update_generative_question_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.update_generative_question_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.update_generative_questions_feature_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/generative_question_service.update_generative_questions_feature_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/merchant_center_account_link_service.create_merchant_center_account_link.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/merchant_center_account_link_service.create_merchant_center_account_link.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/merchant_center_account_link_service.delete_merchant_center_account_link.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/merchant_center_account_link_service.delete_merchant_center_account_link.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/merchant_center_account_link_service.list_merchant_center_account_links.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/merchant_center_account_link_service.list_merchant_center_account_links.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.create_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.create_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.delete_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.delete_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.get_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.get_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.list_models.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.list_models.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.pause_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.pause_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.resume_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.resume_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.tune_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.tune_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.update_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/model_service.update_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/prediction_service.predict.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/prediction_service.predict.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.add_fulfillment_places.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.add_fulfillment_places.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.add_local_inventories.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.add_local_inventories.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.create_product.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.create_product.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.delete_product.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.delete_product.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.export_products.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.export_products.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.get_product.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.get_product.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.import_products.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.import_products.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.list_products.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.list_products.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.purge_products.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.purge_products.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.remove_fulfillment_places.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.remove_fulfillment_places.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.remove_local_inventories.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.remove_local_inventories.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.set_inventory.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.set_inventory.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.update_product.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/product_service.update_product.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.accept_terms.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.accept_terms.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.enroll_solution.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.enroll_solution.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.get_alert_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.get_alert_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.get_logging_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.get_logging_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.get_project.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.get_project.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.list_enrolled_solutions.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.list_enrolled_solutions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.update_alert_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.update_alert_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.update_logging_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/project_service.update_logging_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/search_service.search.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/search_service.search.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.add_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.add_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.create_serving_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.create_serving_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.delete_serving_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.delete_serving_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.get_serving_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.get_serving_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.list_serving_configs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.list_serving_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.remove_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.remove_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.update_serving_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/serving_config_service.update_serving_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.collect_user_event.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.collect_user_event.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.export_user_events.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.export_user_events.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.import_user_events.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.import_user_events.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.purge_user_events.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.purge_user_events.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.rejoin_user_events.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.rejoin_user_events.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.write_user_event.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail-esm/samples/generated/v2alpha/user_event_service.write_user_event.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'retail',

--- a/generator/gapic-generator-typescript/baselines/retail/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/analytics_service.export_analytics_metrics.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/analytics_service.export_analytics_metrics.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/branch_service.get_branch.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/branch_service.get_branch.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/branch_service.list_branches.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/branch_service.list_branches.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.add_catalog_attribute.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.add_catalog_attribute.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.batch_remove_catalog_attributes.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.batch_remove_catalog_attributes.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.get_attributes_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.get_attributes_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.get_completion_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.get_completion_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.get_default_branch.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.get_default_branch.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.list_catalogs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.list_catalogs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.remove_catalog_attribute.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.remove_catalog_attribute.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.replace_catalog_attribute.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.replace_catalog_attribute.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.set_default_branch.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.set_default_branch.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.update_attributes_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.update_attributes_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.update_catalog.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.update_catalog.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.update_completion_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/catalog_service.update_completion_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/completion_service.complete_query.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/completion_service.complete_query.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/completion_service.import_completion_data.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/completion_service.import_completion_data.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.create_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.create_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.delete_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.delete_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.get_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.get_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.list_controls.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.list_controls.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.update_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/control_service.update_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/conversational_search_service.conversational_search.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/conversational_search_service.conversational_search.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.batch_update_generative_question_configs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.batch_update_generative_question_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.get_generative_questions_feature_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.get_generative_questions_feature_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.list_generative_question_configs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.list_generative_question_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.update_generative_question_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.update_generative_question_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.update_generative_questions_feature_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/generative_question_service.update_generative_questions_feature_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/merchant_center_account_link_service.create_merchant_center_account_link.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/merchant_center_account_link_service.create_merchant_center_account_link.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/merchant_center_account_link_service.delete_merchant_center_account_link.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/merchant_center_account_link_service.delete_merchant_center_account_link.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/merchant_center_account_link_service.list_merchant_center_account_links.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/merchant_center_account_link_service.list_merchant_center_account_links.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.create_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.create_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.delete_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.delete_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.get_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.get_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.list_models.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.list_models.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.pause_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.pause_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.resume_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.resume_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.tune_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.tune_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.update_model.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/model_service.update_model.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/prediction_service.predict.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/prediction_service.predict.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.add_fulfillment_places.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.add_fulfillment_places.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.add_local_inventories.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.add_local_inventories.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.create_product.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.create_product.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.delete_product.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.delete_product.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.export_products.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.export_products.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.get_product.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.get_product.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.import_products.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.import_products.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.list_products.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.list_products.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.purge_products.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.purge_products.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.remove_fulfillment_places.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.remove_fulfillment_places.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.remove_local_inventories.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.remove_local_inventories.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.set_inventory.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.set_inventory.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.update_product.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/product_service.update_product.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.accept_terms.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.accept_terms.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.enroll_solution.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.enroll_solution.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.get_alert_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.get_alert_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.get_logging_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.get_logging_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.get_project.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.get_project.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.list_enrolled_solutions.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.list_enrolled_solutions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.update_alert_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.update_alert_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.update_logging_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/project_service.update_logging_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/search_service.search.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/search_service.search.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.add_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.add_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.create_serving_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.create_serving_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.delete_serving_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.delete_serving_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.get_serving_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.get_serving_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.list_serving_configs.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.list_serving_configs.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.remove_control.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.remove_control.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.update_serving_config.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/serving_config_service.update_serving_config.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.collect_user_event.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.collect_user_event.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.export_user_events.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.export_user_events.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.import_user_events.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.import_user_events.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.purge_user_events.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.purge_user_events.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.rejoin_user_events.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.rejoin_user_events.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.write_user_event.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/samples/generated/v2alpha/user_event_service.write_user_event.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/analytics_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/analytics_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/branch_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/branch_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/catalog_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/catalog_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/completion_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/completion_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/control_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/control_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/conversational_search_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/conversational_search_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/generative_question_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/generative_question_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/merchant_center_account_link_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/merchant_center_account_link_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/model_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/model_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/prediction_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/prediction_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/product_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/product_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/project_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/project_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/search_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/search_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/serving_config_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/serving_config_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/user_event_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/src/v2alpha/user_event_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_analytics_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_analytics_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_branch_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_branch_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_catalog_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_catalog_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_completion_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_completion_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_control_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_control_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_conversational_search_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_conversational_search_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_generative_question_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_generative_question_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_merchant_center_account_link_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_merchant_center_account_link_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_model_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_model_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_prediction_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_prediction_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_product_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_product_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_project_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_project_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_search_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_search_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_serving_config_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_serving_config_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/retail/test/gapic_user_event_service_v2alpha.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/retail/test/gapic_user_event_service_v2alpha.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'routingtest',

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/src/v1/test_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/esm/test/gapic_test_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/samples/generated/v1/test_service.fast_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/samples/generated/v1/test_service.fast_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/samples/generated/v1/test_service.random_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/samples/generated/v1/test_service.random_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest-esm/samples/generated/v1/test_service.slow_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest-esm/samples/generated/v1/test_service.slow_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'routingtest',

--- a/generator/gapic-generator-typescript/baselines/routingtest/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/samples/generated/v1/test_service.fast_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/samples/generated/v1/test_service.fast_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/samples/generated/v1/test_service.random_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/samples/generated/v1/test_service.random_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/samples/generated/v1/test_service.slow_fibonacci.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/samples/generated/v1/test_service.slow_fibonacci.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/src/v1/test_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/src/v1/test_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/routingtest/test/gapic_test_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/compliance_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/identity_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/messaging_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/sequence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/src/v1beta1/testing_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_compliance_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_identity_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_messaging_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-esm/esm/test/gapic_testing_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/esm/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.block.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.block.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.chat.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.chat.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.collect.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.collect.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.echo.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.echo.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.echo_error_details.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.echo_error_details.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.expand.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.expand.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand_legacy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand_legacy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand_legacy_mapped.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.paged_expand_legacy_mapped.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.wait.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy-esm/samples/generated/v1beta1/echo.wait.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.block.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.block.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.chat.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.chat.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.collect.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.collect.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.echo.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.echo.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.echo_error_details.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.echo_error_details.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.expand.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.expand.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand_legacy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand_legacy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand_legacy_mapped.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.paged_expand_legacy_mapped.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.wait.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/samples/generated/v1beta1/echo.wait.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase-legacy/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'showcase',

--- a/generator/gapic-generator-typescript/baselines/showcase/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/compliance_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/echo_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/echo_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/identity_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/identity_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/messaging_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/sequence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/testing_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/src/v1beta1/testing_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/test/gapic_compliance_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/test/gapic_echo_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/test/gapic_identity_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/test/gapic_messaging_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/test/gapic_sequence_service_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/showcase/test/gapic_testing_v1beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'tasks',

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/esm/src/v2/cloud_tasks_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/esm/src/v2/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/esm/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/esm/test/gapic_cloud_tasks_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.create_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.create_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.create_task.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.create_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.delete_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.delete_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.delete_task.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.delete_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_iam_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_iam_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_task.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.get_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.list_queues.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.list_queues.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.list_tasks.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.list_tasks.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.pause_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.pause_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.purge_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.purge_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.resume_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.resume_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.run_task.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.run_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.set_iam_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.set_iam_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.test_iam_permissions.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.test_iam_permissions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.update_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks-esm/samples/generated/v2/cloud_tasks.update_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'tasks',

--- a/generator/gapic-generator-typescript/baselines/tasks/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.create_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.create_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.create_task.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.create_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.delete_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.delete_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.delete_task.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.delete_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.get_iam_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.get_iam_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.get_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.get_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.get_task.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.get_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.list_queues.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.list_queues.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.list_tasks.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.list_tasks.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.pause_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.pause_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.purge_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.purge_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.resume_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.resume_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.run_task.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.run_task.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.set_iam_policy.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.set_iam_policy.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.test_iam_permissions.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.test_iam_permissions.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.update_queue.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/samples/generated/v2/cloud_tasks.update_queue.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/src/v2/cloud_tasks_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/src/v2/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/src/v2/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/tasks/test/gapic_cloud_tasks_v2.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/text-to-speech',

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/src/v1/text_to_speech_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/esm/test/gapic_text_to_speech_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/samples/generated/v1/text_to_speech.list_voices.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/samples/generated/v1/text_to_speech.list_voices.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech-esm/samples/generated/v1/text_to_speech.synthesize_speech.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech-esm/samples/generated/v1/text_to_speech.synthesize_speech.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: '@google-cloud/text-to-speech',

--- a/generator/gapic-generator-typescript/baselines/texttospeech/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/samples/generated/v1/text_to_speech.list_voices.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/samples/generated/v1/text_to_speech.list_voices.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/samples/generated/v1/text_to_speech.synthesize_speech.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/samples/generated/v1/text_to_speech.synthesize_speech.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/src/v1/text_to_speech_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/texttospeech/test/gapic_text_to_speech_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'translation',

--- a/generator/gapic-generator-typescript/baselines/translate-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/esm/src/v3beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/esm/src/v3beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/esm/src/v3beta1/translation_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/esm/test/gapic_translation_service_v3beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.batch_translate_text.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.batch_translate_text.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.create_glossary.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.create_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.delete_glossary.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.delete_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.detect_language.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.detect_language.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.get_glossary.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.get_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.get_supported_languages.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.get_supported_languages.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.list_glossaries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.list_glossaries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.translate_text.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate-esm/samples/generated/v3beta1/translation_service.translate_text.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'translation',

--- a/generator/gapic-generator-typescript/baselines/translate/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.batch_translate_text.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.batch_translate_text.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.create_glossary.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.create_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.delete_glossary.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.delete_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.detect_language.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.detect_language.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.get_glossary.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.get_glossary.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.get_supported_languages.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.get_supported_languages.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.list_glossaries.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.list_glossaries.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.translate_text.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/samples/generated/v3beta1/translation_service.translate_text.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/src/v3beta1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/src/v3beta1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/src/v3beta1/translation_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/translate/test/gapic_translation_service_v3beta1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/.jsdoc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/.jsdoc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'videointelligence',

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/.mocharc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/.mocharc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/.prettierrc.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/.prettierrc.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/src/v1/video_intelligence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.cjs.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require, no-unused-vars, no-undef */
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/esm/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence-esm/samples/generated/v1/video_intelligence_service.annotate_video.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence-esm/samples/generated/v1/video_intelligence_service.annotate_video.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/.jsdoc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/.jsdoc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ module.exports = {
     includePattern: '\\.js$'
   },
   templates: {
-    copyright: 'Copyright 2025 Google LLC',
+    copyright: 'Copyright 2026 Google LLC',
     includeDate: false,
     sourceFiles: false,
     systemName: 'videointelligence',

--- a/generator/gapic-generator-typescript/baselines/videointelligence/.mocharc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/.mocharc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/.prettierrc.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/.prettierrc.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/samples/generated/v1/video_intelligence_service.annotate_video.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/samples/generated/v1/video_intelligence_service.annotate_video.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/src/v1/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/src/v1/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/src/v1/video_intelligence_service_client.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/system-test/fixtures/sample/src/index.js.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/system-test/fixtures/sample/src/index.js.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/system-test/fixtures/sample/src/index.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/system-test/fixtures/sample/src/index.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/system-test/install.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/system-test/install.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/gapic-generator-typescript/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
+++ b/generator/gapic-generator-typescript/baselines/videointelligence/test/gapic_video_intelligence_service_v1.ts.baseline
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the copyright year to 2026 to ensure this change isn't bundled with future baseline generations.

Unblocks #885 