### PR TITLE
fix: do not generate stubMethodsContent if there are no methods

### DIFF
--- a/generator/gapic-generator-typescript/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
+++ b/generator/gapic-generator-typescript/templates/cjs/typescript_gapic/src/$version/$service_client.ts.njk
@@ -438,10 +438,7 @@ export class {{ service.name }}Client {
           (this._protos as any).{{api.naming.protoPackage}}.{{ service.name }},
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;
 
-    // Iterate over each of the methods that the service provides
-    // and create an API call method for each.
-    const {{ service.name.toCamelCase() }}StubMethods =
-        [
+    {%- set stubMethodsContent %}
 {%- set stubMethodsJoiner = joiner(', ') -%}
 {%- for method in service.method -%}
       {%- if not method.ignoreMapPagingMethod %}
@@ -449,7 +446,13 @@ export class {{ service.name }}Client {
       '{{ method.name.toCamelCase(true) }}'
       {%- endif %}
 {%- endfor -%}
-    ];
+{% endset -%}
+{%- if stubMethodsContent | trim %}
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    const {{ service.name.toCamelCase() }}StubMethods =
+        [{{ stubMethodsContent | safe }}];
     for (const methodName of {{ service.name.toCamelCase() }}StubMethods) {
       const callPromise = this.{{ service.name.toCamelCase() }}Stub.then(
         stub => (...args: Array<{}>) => {
@@ -495,6 +498,7 @@ export class {{ service.name }}Client {
 
       this.innerApiCalls[methodName] = apiCall;
     }
+{%- endif -%}
     {%- if service.options and service.options.deprecated %}
     this.warn('DEP${{service.name}}', '{{service.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}

--- a/generator/gapic-generator-typescript/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
+++ b/generator/gapic-generator-typescript/templates/esm/typescript_gapic/esm/src/$version/$service_client.ts.njk
@@ -449,10 +449,7 @@ export class {{ service.name }}Client {
           (this._protos as any).{{api.naming.protoPackage}}.{{ service.name }},
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;
 
-    // Iterate over each of the methods that the service provides
-    // and create an API call method for each.
-    const {{ service.name.toCamelCase() }}StubMethods =
-        [
+     {%- set stubMethodsContent %}
 {%- set stubMethodsJoiner = joiner(', ') -%}
 {%- for method in service.method -%}
       {%- if not method.ignoreMapPagingMethod %}
@@ -460,7 +457,13 @@ export class {{ service.name }}Client {
       '{{ method.name.toCamelCase(true) }}'
       {%- endif %}
 {%- endfor -%}
-    ];
+{% endset -%}
+{%- if stubMethodsContent | trim %}
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    const {{ service.name.toCamelCase() }}StubMethods =
+        [{{ stubMethodsContent | safe }}];
     for (const methodName of {{ service.name.toCamelCase() }}StubMethods) {
       const callPromise = this.{{ service.name.toCamelCase() }}Stub.then(
         stub => (...args: Array<{}>) => {
@@ -506,6 +509,7 @@ export class {{ service.name }}Client {
 
       this.innerApiCalls[methodName] = apiCall;
     }
+{%- endif -%}
     {%- if service.options and service.options.deprecated %}
     this.warn('DEP${{service.name}}', '{{service.name}} is deprecated and may be removed in a future version.', 'DeprecationWarning');
     {%- endif %}


### PR DESCRIPTION
fixes this problem in this PR: https://github.com/googleapis/google-cloud-node/actions/runs/20862284893/job/59944732536

basically, the issue is that we're missing a type annotation since we're instantiating an empty array. But, we shouldn't even generate this array or iterate over it if it's going to be empty. So this code just adds a branch block to skip it.