### PR TITLE
chore: replace old nodejs teams with cloud-sdk-nodejs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/jsteam @yoshi-approver
+*     @googleapis/cloud-sdk-nodejs-team @yoshi-approver


### PR DESCRIPTION
b/479541676