### PR TITLE
Revert "chore: release main"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,7 +6,7 @@
   "packages/gax": "5.0.6",
   "packages/gaxios": "7.1.4",
   "packages/gcp-metadata": "8.1.2",
-  "packages/google-auth-library-nodejs": "10.6.1",
+  "packages/google-auth-library-nodejs": "10.6.0",
   "packages/logging-utils": "1.1.3",
   "packages/nodejs-googleapis-common": "8.0.1",
   "packages/nodejs-proto-files": "6.0.0",

--- a/packages/google-auth-library-nodejs/CHANGELOG.md
+++ b/packages/google-auth-library-nodejs/CHANGELOG.md
@@ -4,13 +4,6 @@
 
 [1]: https://www.npmjs.com/package/google-auth-library?activeTab=versions
 
-## [10.6.1](https://github.com/googleapis/google-cloud-node-core/compare/google-auth-library-v10.6.0...google-auth-library-v10.6.1) (2026-02-20)
-
-
-### Bug Fixes
-
-* DefaultAwsSecurityCredentialSupplier fetches aws-credentials correctly from credential-url ([#901](https://github.com/googleapis/google-cloud-node-core/issues/901)) ([8c50526](https://github.com/googleapis/google-cloud-node-core/commit/8c5052677953ba2940583e28d6691f0e38ba8c1a))
-
 ## [10.6.0](https://github.com/googleapis/google-cloud-node-core/compare/google-auth-library-v10.5.0...google-auth-library-v10.6.0) (2025-12-17)
 
 

--- a/packages/google-auth-library-nodejs/package.json
+++ b/packages/google-auth-library-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-auth-library",
-  "version": "10.6.1",
+  "version": "10.6.0",
   "author": "Google Inc.",
   "description": "Google APIs Authentication Client Library for Node.js",
   "engines": {

--- a/packages/google-auth-library-nodejs/samples/package.json
+++ b/packages/google-auth-library-nodejs/samples/package.json
@@ -17,7 +17,7 @@
     "@google-cloud/storage": "^7.0.0",
     "@aws-sdk/credential-providers": "^3.58.0",
     "@googleapis/iam": "^34.0.0",
-    "google-auth-library": "^10.6.1",
+    "google-auth-library": "^10.6.0",
     "dotenv": "^17.0.0",
     "gaxios": "^7.0.0",
     "node-fetch": "^2.3.0",


### PR DESCRIPTION
Reverts googleapis/google-cloud-node-core#904

Will re-merge to run the release job correctly